### PR TITLE
chore: prepare to use tree-sitter-symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cc"
+version = "1.2.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +224,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "float-cmp"
@@ -503,6 +519,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65da48d447333cebe1aadbdd3662f3ba56e76e67f53bc46f3dd5f67c74629d6b"
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +541,12 @@ name = "str_indices"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "syn"
@@ -561,6 +589,37 @@ dependencies = [
  "predicates",
  "ropey",
  "tempfile",
+ "tree-sitter",
+ "tree-sitter-rust",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5387dffa7ffc7d2dae12b50c6f7aab8ff79d6210147c6613561fc3d474c6f75"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b18034c684a2420722be8b2a91c9c44f2546b631c039edf575ccba8c61be1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,17 @@ name = "textum"
 path = "src/cli.rs"
 
 [dependencies]
+ropey = "1.6"
+
+# Optional dependencies
+# -- Facet
 facet = { optional = true, version = "0.30.0" }
 facet-args = { optional = true, version = "0.30.0" }
 facet-json = { optional = true, version = "0.30.0" }
-ropey = "1.6"
+
+# -- Symbols
+tree-sitter = { optional = true, version = "0.24.0" }
+tree-sitter-rust = { optional = true, version = "0.24.0" }
 
 [package]
 authors = ["Louis Maddox <louismmx@gmail.com>"]
@@ -70,7 +77,16 @@ cli = ["all-patch-fields", "dep:facet-args", "json"]
 facet = ["dep:facet"]
 json = ["dep:facet-json", "facet"]
 
+# --- Symbol paths
+ts-base = ["dep:tree-sitter"]
+ts-full = ["ts-rust"]
+# --- Symbol paths -- tree-sitter languages
+ts-rust = ["dep:tree-sitter-rust", "ts-base"] # TODO: tree-sitter-symbols-rust
+
 [dev-dependencies]
 assert_cmd = "2.1.1"
 predicates = "3.1.3"
 tempfile = "3.23.0"
+
+[package.metadata.cargo-machete]
+ignored = ["tree-sitter", "tree-sitter-rust"]

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -1,0 +1,10 @@
+use tree_sitter_symbols_rust::NodeType;
+
+pub struct SymbolPath {
+    pub segments: Vec<SymbolSegment>,
+}
+
+pub struct SymbolSegment {
+    pub node_type: NodeType,
+    pub name: Option<String>,
+}


### PR DESCRIPTION
Since we want symbol paths we need symbols. I just don't want to force people to opt into huge APIs
(like some are doing via codegen) if all they want is one target.

- CLIs are fine to do it for, they need the optionality. Not library users
- Make a new `tree-sitter-symbols` repo and `tree-sitter-symbols-rust` dep to use

(Blocked until that ships)

**Update**: that has shipped, this is no longer blocked but now I need to ship this crate to use in that
one! Not a problem, just will ship with non-functional features for these symbol paths (fine)
